### PR TITLE
Refacto des modèles GA4 : renommage stg_google_analytics_event_flatte…

### DIFF
--- a/models/intermediate/dataset_fil_rouge/int_dataset_fil_rouge__user.sql
+++ b/models/intermediate/dataset_fil_rouge/int_dataset_fil_rouge__user.sql
@@ -1,0 +1,44 @@
+WITH 
+  orders_summary AS (
+    SELECT
+      o.user_id,
+      SUM((oi.unit_price * oi.item_quantity + oi.shipping_cost)) AS total_order_spent,
+      SUM(oi.item_quantity) AS total_items,
+      COUNT(DISTINCT(product_id)) AS total_distinct_items,
+      COUNT(DISTINCT o.order_id) AS total_orders
+    FROM {{ ref('stg_dataset_fil_rouge_order_item') }} oi
+    INNER JOIN {{ ref('stg_dataset_fil_rouge_order') }} o
+      USING(order_id)
+    GROUP BY 
+      o.user_id
+  ),
+
+  product_summary AS (
+    SELECT
+      o.user_id,
+      oi.product_id,
+      SUM(oi.item_quantity) AS quantity_ordered,
+      ROW_NUMBER() OVER (
+      PARTITION BY o.user_id
+      ORDER BY SUM(item_quantity) DESC
+      ) AS rank 
+    FROM {{ ref('stg_dataset_fil_rouge_order') }} o
+    LEFT JOIN {{ ref('stg_dataset_fil_rouge_order_item') }} oi
+      USING (order_id)
+    GROUP BY 
+      o.user_id,
+      oi.product_id
+  )
+
+  SELECT 
+    os.user_id,
+    os.total_order_spent,
+    os.total_distinct_items,
+    os.total_orders,
+    ps.product_id AS favorite_product,
+    ps.quantity_ordered
+  FROM orders_summary os
+  LEFT JOIN product_summary ps
+    ON os.user_id = ps.user_id AND rank=1
+  ORDER BY os.total_order_spent DESC 
+  

--- a/models/intermediate/google_analytics/int_google_analytics__session.sql
+++ b/models/intermediate/google_analytics/int_google_analytics__session.sql
@@ -1,0 +1,38 @@
+WITH session_data AS (
+SELECT 
+  user_pseudo_id,
+  ga_session_id,
+  CONCAT(ga_session_id,' - ', user_pseudo_id) AS unique_session_id,
+  MIN(TIMESTAMP_MICROS(event_timestamp)) AS session_start_time, 
+  MAX(TIMESTAMP_MICROS(event_timestamp)) AS session_end_time,  
+  MAX(browser) AS browser_used,
+  MAX(medium) AS traffic_medium, 
+  MAX(source) AS traffic_source,
+  MAX(name) AS traffic_name, 
+  COUNT(*) AS event_count,
+  SUM(
+    CASE 
+      WHEN event_name = 'page_view' THEN 1
+      ELSE 0
+      END
+  ) AS pages_viewed
+FROM {{ ref('stg_google_analytics_event_flattened') }}
+GROUP BY 
+  ga_session_id, 
+  user_pseudo_id
+)
+
+SELECT
+  user_pseudo_id,
+  ga_session_id,
+  unique_session_id,
+  session_start_time,
+  session_end_time,
+  TIMESTAMP_DIFF(session_end_time, session_start_time, second) AS session_duration_seconds, 
+  browser_used,
+  traffic_medium,
+  traffic_source,
+  traffic_name,
+  event_count,
+  pages_viewed
+FROM session_data

--- a/models/staging/google_analytics/stg_google_analytics_event_flattened.sql
+++ b/models/staging/google_analytics/stg_google_analytics_event_flattened.sql
@@ -17,8 +17,8 @@ SELECT
    FROM UNNEST(event_params) AS ep
    WHERE ep.key = 'browser') AS browser,
 
-  traffic_source.medium,
-  traffic_source.source,
-  traffic_source.name
+  traffic_source.medium as medium,
+  traffic_source.source as source,
+  traffic_source.name as `name`
 
 FROM {{ source('google_analytics_4', 'events_20210131')}}


### PR DESCRIPTION
- Renommage du modèle stg_google_analytics_4_event_flattened ➝ stg_google_analytics_event_flattened, pour une meilleure lisibilité et alignement avec la structure du projet.
- Suppression de l’ancien fichier obsolète.
- Ajout du modèle int_google_analytics__session, qui permet d’agréger les événements par session :
- Calcul du session_start_time et session_end_time
- Création d’un identifiant unique de session (unique_session_id)
- Comptage des événements et des page_view
- Récupération du browser, traffic_medium, traffic_source, traffic_name

Testé localement :

dbt run effectué avec succès
Vérification de la compatibilité des ref() entre modèles de staging et intermediate